### PR TITLE
escape _ symbol for markdown format

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -84,6 +84,27 @@ func trimElement(keys []string) []string {
 	return newKeys
 }
 
+func escapeMarkdown(keys []string) []string {
+	var newKeys []string
+
+	for _, value := range keys {
+		value = escapeMarkdownOne(value)
+		if len(value) == 0 {
+			continue
+		}
+		newKeys = append(newKeys, value)
+	}
+
+	return newKeys
+}
+
+func escapeMarkdownOne(str string) string {
+	str = strings.Replace(str, `\_`, `_`, -1)
+	str = strings.Replace(str, `_`, `\_`, -1)
+
+	return str
+}
+
 func fileExist(keys []string) []string {
 	var newKeys []string
 
@@ -213,9 +234,25 @@ func (p Plugin) Exec() error {
 	locations := trimElement(p.Config.Location)
 	venues := trimElement(p.Config.Venue)
 
+	message = trimElement(message)
+
+	if p.Config.Format == "markdown" {
+		message = escapeMarkdown(message)
+
+		p.Build.Message = escapeMarkdownOne(p.Build.Author)
+		p.Build.Branch = escapeMarkdownOne(p.Build.Branch)
+		p.Build.Author = escapeMarkdownOne(p.Build.Author)
+		p.Build.Email = escapeMarkdownOne(p.Build.Email)
+		p.Build.Link = escapeMarkdownOne(p.Build.Link)
+		p.Build.PR = escapeMarkdownOne(p.Build.PR)
+
+		p.Repo.Owner = escapeMarkdownOne(p.Repo.Owner)
+		p.Repo.Name = escapeMarkdownOne(p.Repo.Name)
+	}
+
 	// send message.
 	for _, user := range ids {
-		for _, value := range trimElement(message) {
+		for _, value := range message {
 			txt, err := template.RenderTrim(value, p)
 			if err != nil {
 				return err

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -156,6 +156,10 @@ func TestEscapeMarkdown(t *testing.T) {
 			{`user\_name\_long`, `repo\_name\_long`},
 			{`user\_name\_long`, `repo\_name\_long`},
 		},
+		{
+			{`user\_name\_long`, `repo\_name\_long`, ""},
+			{`user\_name\_long`, `repo\_name\_long`},
+		},
 	}
 
 	for _, testCase := range provider {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -86,6 +86,7 @@ func TestSendMessage(t *testing.T) {
 	err := plugin.Exec()
 	assert.Nil(t, err)
 
+	plugin.Config.Format = "markdown"
 	plugin.Config.Message = []string{"Test escape under_score"}
 	err = plugin.Exec()
 	assert.Nil(t, err)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -135,21 +135,21 @@ func TestTrimElement(t *testing.T) {
 
 func TestEscapeMarkdown(t *testing.T) {
 	provider := [][][]string{
-		[][]string{
-			[]string{"user", "repo"},
-			[]string{"user", "repo"},
+		{
+			{"user", "repo"},
+			{"user", "repo"},
 		},
-		[][]string{
-			[]string{"user_name", "repo_name"},
-			[]string{`user\_name`, `repo\_name`},
+		{
+			{"user_name", "repo_name"},
+			{`user\_name`, `repo\_name`},
 		},
-		[][]string{
-			[]string{"user_name_long", "user_name_long"},
-			[]string{`user\_name\_long`, `user\_name\_long`},
+		{
+			{"user_name_long", "user_name_long"},
+			{`user\_name\_long`, `user\_name\_long`},
 		},
-		[][]string{
-			[]string{`user\_name\_long`, `repo\_name\_long`},
-			[]string{`user\_name\_long`, `repo\_name\_long`},
+		{
+			{`user\_name\_long`, `repo\_name\_long`},
+			{`user\_name\_long`, `repo\_name\_long`},
 		},
 	}
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -133,6 +133,31 @@ func TestTrimElement(t *testing.T) {
 	assert.Equal(t, result, trimElement(input))
 }
 
+func TestEscapeMarkdown(t *testing.T) {
+	provider := [][][]string{
+		[][]string{
+			[]string{"user", "repo"},
+			[]string{"user", "repo"},
+		},
+		[][]string{
+			[]string{"user_name", "repo_name"},
+			[]string{`user\_name`, `repo\_name`},
+		},
+		[][]string{
+			[]string{"user_name_long", "user_name_long"},
+			[]string{`user\_name\_long`, `user\_name\_long`},
+		},
+		[][]string{
+			[]string{`user\_name\_long`, `repo\_name\_long`},
+			[]string{`user\_name\_long`, `repo\_name\_long`},
+		},
+	}
+
+	for _, testCase := range provider {
+		assert.Equal(t, testCase[1], escapeMarkdown(testCase[0]))
+	}
+}
+
 func TestParseTo(t *testing.T) {
 	input := []string{"0", "1:1@gmail.com", "2:2@gmail.com", "3:3@gmail.com", "4", "5"}
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -86,6 +86,10 @@ func TestSendMessage(t *testing.T) {
 	err := plugin.Exec()
 	assert.Nil(t, err)
 
+	plugin.Config.Message = []string{"Test escape under_score"}
+	err = plugin.Exec()
+	assert.Nil(t, err)
+
 	// disable message
 	plugin.Config.Message = []string{}
 	err = plugin.Exec()
@@ -155,6 +159,19 @@ func TestEscapeMarkdown(t *testing.T) {
 
 	for _, testCase := range provider {
 		assert.Equal(t, testCase[1], escapeMarkdown(testCase[0]))
+	}
+}
+
+func TestEscapeMarkdownOne(t *testing.T) {
+	provider := [][]string{
+		{"user", "user"},
+		{"user_name", `user\_name`},
+		{"user_name_long", `user\_name\_long`},
+		{`user\_name\_escaped`, `user\_name\_escaped`},
+	}
+
+	for _, testCase := range provider {
+		assert.Equal(t, testCase[1], escapeMarkdownOne(testCase[0]))
 	}
 }
 


### PR DESCRIPTION
Escape underscore symbol for message format markdown

For example, you have _ in your username and use default telegram message
Error: Bad Request: can't parse entities in message text: Can't find end of the entity starting at byte offset