### PR TITLE
Unescape html entities

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:   "format",
-			Value:  "markdown",
+			Value:  formatMarkdown,
 			Usage:  "telegram message format",
 			EnvVar: "PLUGIN_FORMAT,FORMAT,INPUT_FORMAT",
 		},

--- a/plugin.go
+++ b/plugin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io/ioutil"
 	"log"
 	"os"
@@ -315,6 +316,8 @@ func (p Plugin) Exec() (err error) {
 			if err != nil {
 				return err
 			}
+
+			txt = html.UnescapeString(txt)
 
 			msg := tgbotapi.NewMessage(user, txt)
 			msg.ParseMode = p.Config.Format

--- a/plugin.go
+++ b/plugin.go
@@ -16,6 +16,10 @@ import (
 	tgbotapi "gopkg.in/telegram-bot-api.v4"
 )
 
+const (
+	formatMarkdown = "markdown"
+)
+
 type (
 	// GitHub information.
 	GitHub struct {
@@ -287,7 +291,7 @@ func (p Plugin) Exec() (err error) {
 
 	message = trimElement(message)
 
-	if p.Config.Format == "markdown" {
+	if p.Config.Format == formatMarkdown {
 		message = escapeMarkdown(message)
 
 		p.Commit.Message = escapeMarkdownOne(p.Commit.Message)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -112,7 +112,7 @@ func TestSendMessage(t *testing.T) {
 	err := plugin.Exec()
 	assert.NotNil(t, err)
 
-	plugin.Config.Format = "markdown"
+	plugin.Config.Format = formatMarkdown
 	plugin.Config.Message = []string{"Test escape under_score"}
 	err = plugin.Exec()
 	assert.NotNil(t, err)
@@ -376,7 +376,7 @@ func TestTemplateVars(t *testing.T) {
 		Config: Config{
 			Token:        os.Getenv("TELEGRAM_TOKEN"),
 			To:           []string{os.Getenv("TELEGRAM_TO")},
-			Format:       "markdown",
+			Format:       formatMarkdown,
 			MessageFile:  "tests/message_template.txt",
 			TemplateVars: `{"env":"testing","version":"1.2.0-SNAPSHOT"}`,
 		},


### PR DESCRIPTION
Some characters, such as the apostrophe ('), are too common within commit messages, and they are getting sent as HTML entities that Telegram cannot render (&apos; for the character ' ).

This PR unescapes all texts to make sure that such characters are sent as proper characters.

Fixes #50 
