### PR TITLE
Add socks5 proxy to plugin

### DIFF
--- a/main.go
+++ b/main.go
@@ -245,6 +245,11 @@ func main() {
 			Usage:  "Provides the target deployment environment for the running build. This value is only available to promotion and rollback pipelines.",
 			EnvVar: "DRONE_DEPLOY_TO",
 		},
+		cli.StringFlag{
+			Name:   "socks5",
+			Usage:  "Socks5 proxy URL",
+			EnvVar: "PLUGIN_SOCKS5,SOCKS5",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -310,6 +315,7 @@ func run(c *cli.Context) error {
 			Venue:        c.StringSlice("venue"),
 			Format:       c.String("format"),
 			GitHub:       c.Bool("github"),
+			Socks5:       c.String("socks5"),
 		},
 	}
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -385,3 +385,54 @@ func TestTemplateVars(t *testing.T) {
 	err := plugin.Exec()
 	assert.Nil(t, err)
 }
+
+func TestProxySendMessage(t *testing.T) {
+	plugin := Plugin{
+		Repo: Repo{
+			Name:      "go-hello",
+			Namespace: "appleboy",
+		},
+		Commit: Commit{
+			Sha:     "e7c4f0a63ceeb42a39ac7806f7b51f3f0d204fd2",
+			Author:  "Bo-Yi Wu",
+			Branch:  "master",
+			Message: "start use proxy",
+			Email:   "test@gmail.com",
+		},
+		Build: Build{
+			Tag:    "1.0.0",
+			Number: 101,
+			Status: "success",
+			Link:   "https://github.com/appleboy/go-hello",
+		},
+
+		Config: Config{
+			Token:    os.Getenv("TELEGRAM_TOKEN"),
+			To:       []string{os.Getenv("TELEGRAM_TO"), os.Getenv("TELEGRAM_TO") + ":appleboy@gmail.com", "中文ID", "1234567890"},
+			Message:  []string{"Test Telegram Chat Bot From Travis or Local", "commit message: 『{{ build.message }}』", " "},
+			Photo:    []string{"tests/github.png", "1234", " "},
+			Document: []string{"tests/gophercolor.png", "1234", " "},
+			Sticker:  []string{"tests/github-logo.png", "tests/github.png", "1234", " "},
+			Audio:    []string{"tests/audio.mp3", "1234", " "},
+			Voice:    []string{"tests/voice.ogg", "1234", " "},
+			Location: []string{"24.9163213 121.1424972", "1", " "},
+			Venue:    []string{"35.661777 139.704051 竹北體育館 新竹縣竹北市", "24.9163213 121.1424972", "1", " "},
+			Video:    []string{"tests/video.mp4", "1234", " "},
+			Debug:    false,
+			Socks5:   os.Getenv("SOCKS5"),
+		},
+	}
+
+	err := plugin.Exec()
+	assert.NotNil(t, err)
+
+	plugin.Config.Format = formatMarkdown
+	plugin.Config.Message = []string{"Test escape under_score"}
+	err = plugin.Exec()
+	assert.NotNil(t, err)
+
+	// disable message
+	plugin.Config.Message = []string{}
+	err = plugin.Exec()
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
Hello from Russia. 
Found Issue https://github.com/appleboy/drone-telegram/issues/78 and not closed PR https://github.com/appleboy/drone-telegram/pull/80. 
Add socks5 proxy env var to app and test to it usage. 
Hope, you`ll merge it and I can use plugin in our CI/CD.