### PR TITLE
fix: pick the build status variable from env file in k8s pipelines, close #90

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,15 @@ var (
 )
 
 func main() {
+	// in k8s pipelines the variables are provisioned beforehand
+	// that's why the build status cannot be actual
+	// however the actual variables are automatically provisioned in /run/drone/env
+	// see https://discourse.drone.io/t/drone-build-status-always-success-in-kubernetes/6627 for more info
+	if os.Getenv("DRONE_STAGE_TYPE") == "kubernetes" {
+		// overload is important here to overwrite the outdated env variables from the container
+		_ = godotenv.Overload("/run/drone/env")
+	}
+
 	// Load env-file if it exists first
 	if filename, found := os.LookupEnv("PLUGIN_ENV_FILE"); found {
 		_ = godotenv.Load(filename)


### PR DESCRIPTION
Hi @appleboy 

thank you for fixing the env file setting, this let me further debug the issue on k8s and create a fix for #90 

Please have a look and let me know what you think.