### PR TITLE
add disable_notification parameter

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -233,8 +233,20 @@ Disables link previews for links in this message
     settings:
       token: xxxxxxxxxx
       to: telegram_user_id
-      message: send message using custom socks5 URL
+      message: send message without a link preview
 +     disable_web_page_preview: true
+```
+
+Disables notifications for this message
+
+```diff
+  - name: send telegram notification
+    image: appleboy/drone-telegram
+    settings:
+      token: xxxxxxxxxx
+      to: telegram_user_id
+      message: send message message silently
++     disable_notification: true
 ```
 
 ## Parameter Reference

--- a/main.go
+++ b/main.go
@@ -114,6 +114,11 @@ func main() {
 			Usage:  "disables link previews for links in this message",
 			EnvVar: "PLUGIN_DISABLE_WEB_PAGE_PREVIEW,INPUT_DISABLE_WEB_PAGE_PREVIEW",
 		},
+		cli.BoolFlag{
+			Name:   "disable.notification",
+			Usage:  "sends the message silently. users will receive a notification with no sound.",
+			EnvVar: "PLUGIN_DISABLE_NOTIFICATION,INPUT_DISABLE_NOTIFICATION",
+		},
 		cli.StringFlag{
 			Name:   "format",
 			Value:  formatMarkdown,
@@ -322,6 +327,7 @@ func run(c *cli.Context) error {
 			Socks5:           c.String("socks5"),
 
 			DisableWebPagePreview: c.Bool("disable.webpage.preview"),
+			DisableNotification: c.Bool("disable.notification"),
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -327,7 +327,7 @@ func run(c *cli.Context) error {
 			Socks5:           c.String("socks5"),
 
 			DisableWebPagePreview: c.Bool("disable.webpage.preview"),
-			DisableNotification: c.Bool("disable.notification"),
+			DisableNotification:   c.Bool("disable.notification"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -88,7 +88,7 @@ type (
 		Socks5           string
 
 		DisableWebPagePreview bool
-		DisableNotification bool
+		DisableNotification   bool
 	}
 
 	// Plugin values.

--- a/plugin.go
+++ b/plugin.go
@@ -88,6 +88,7 @@ type (
 		Socks5           string
 
 		DisableWebPagePreview bool
+		DisableNotification bool
 	}
 
 	// Plugin values.
@@ -365,6 +366,7 @@ func (p Plugin) Exec() (err error) {
 			msg := tgbotapi.NewMessage(user, txt)
 			msg.ParseMode = p.Config.Format
 			msg.DisableWebPagePreview = p.Config.DisableWebPagePreview
+			msg.DisableNotification = p.Config.DisableNotification
 			if err := p.Send(bot, msg); err != nil {
 				return err
 			}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -148,10 +148,10 @@ func TestDisableWebPagePreviewMessage(t *testing.T) {
 func TestDisableNotificationMessage(t *testing.T) {
 	plugin := Plugin{
 		Config: Config{
-			Token:                 os.Getenv("TELEGRAM_TOKEN"),
-			To:                    []string{os.Getenv("TELEGRAM_TO")},
-			DisableNotification:   true,
-			Debug:                 false,
+			Token:               os.Getenv("TELEGRAM_TOKEN"),
+			To:                  []string{os.Getenv("TELEGRAM_TO")},
+			DisableNotification: true,
+			Debug:               false,
 		},
 	}
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -150,7 +150,7 @@ func TestDisableNotificationMessage(t *testing.T) {
 		Config: Config{
 			Token:                 os.Getenv("TELEGRAM_TOKEN"),
 			To:                    []string{os.Getenv("TELEGRAM_TO")},
-			DisableNotification: true,
+			DisableNotification:   true,
 			Debug:                 false,
 		},
 	}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -145,6 +145,27 @@ func TestDisableWebPagePreviewMessage(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestDisableNotificationMessage(t *testing.T) {
+	plugin := Plugin{
+		Config: Config{
+			Token:                 os.Getenv("TELEGRAM_TOKEN"),
+			To:                    []string{os.Getenv("TELEGRAM_TO")},
+			DisableNotification: true,
+			Debug:                 false,
+		},
+	}
+
+	plugin.Config.Message = "DisableNotification https://www.google.com.tw"
+	err := plugin.Exec()
+	assert.Nil(t, err)
+
+	// disable message
+	plugin.Config.DisableNotification = false
+	plugin.Config.Message = "EnableNotification https://www.google.com.tw"
+	err = plugin.Exec()
+	assert.Nil(t, err)
+}
+
 func TestBotError(t *testing.T) {
 	plugin := Plugin{
 		Repo: Repo{


### PR DESCRIPTION
i am using [appleboy/telegram-action](https://github.com/appleboy/telegram-action) for multiple of my projects and I'd prefer to just send a silent notification on commit, because most times it is not that urgent.

i've opened appleboy/telegram-action#26 but haven't received any response, so i decided to contribute myself.

although i am not a go developer i've tried my best by searching for every mention of the disable_web_page_preview flag and copying the relevant code. so it should just work.