### PR TITLE
escape * symbol for markdown format

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -148,6 +148,8 @@ func escapeMarkdown(keys []string) []string {
 func escapeMarkdownOne(str string) string {
 	str = strings.Replace(str, `\_`, `_`, -1)
 	str = strings.Replace(str, `_`, `\_`, -1)
+	str = strings.Replace(str, `\*`, `*`, -1)
+	str = strings.Replace(str, `*`, `\*`, -1)
 
 	return str
 }


### PR DESCRIPTION
An error is returned when send a markdown message with the symbol *.

error：
Bad Request: can't parse entities: Can't find end of the entity starting at byte offset ...
