### PR TITLE
{{since build.started}} does not reflect the actual build time in a p…

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,7 +216,7 @@ func main() {
 		cli.Int64Flag{
 			Name:   "build.started",
 			Usage:  "build started",
-			EnvVar: "DRONE_BUILD_STARTED",
+			EnvVar: "DRONE_STAGE_STARTED",
 		},
 		cli.Int64Flag{
 			Name:   "build.finished",


### PR DESCRIPTION
…ipeline #108

replaced with DRONE_STAGE_STARTED 

https://docs.drone.io/pipeline/environment/reference/drone-stage-started/

> Provides the unix timestamp for when the **pipeline** was started by the runner.

