### PR TITLE
Support superchats

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,12 +3,12 @@ FROM alpine:3.17
 ARG TARGETOS
 ARG TARGETARCH
 
-LABEL maintainer="Bo-Yi Wu <appleboy.tw@gmail.com>" \
+LABEL maintainer="Nik Ushmodin <ushmodin@gmail.com>" \
   org.label-schema.name="Telegram Plugin" \
-  org.label-schema.vendor="Bo-Yi Wu" \
+  org.label-schema.vendor="Nik Ushmodin" \
   org.label-schema.schema-version="1.0"
 
-LABEL org.opencontainers.image.source=https://github.com/appleboy/drone-telegram
+LABEL org.opencontainers.image.source=https://github.com/ushmodin/drone-telegram
 LABEL org.opencontainers.image.description="plugin for sending telegram notifications"
 LABEL org.opencontainers.image.licenses=MIT
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/appleboy/drone-template-lib v1.3.0
-	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
+	github.com/go-telegram/bot v1.17.0
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli v1.22.15
@@ -27,7 +27,6 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
-	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible h1:2cauKuaELYAEARXRkq2LrJ0yDDv1rW7+wrTEdVL3uaU=
-github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible/go.mod h1:qf9acutJ8cwBUhm1bqgz6Bei9/C/c93FPDljKWwsOgM=
+github.com/go-telegram/bot v1.17.0 h1:Hs0kGxSj97QFqOQP0zxduY/4tSx8QDzvNI9uVRS+zmY=
+github.com/go-telegram/bot v1.17.0/go.mod h1:i2TRs7fXWIeaceF3z7KzsMt/he0TwkVC680mvdTFYeM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -60,8 +60,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/technoweenie/multipartstreamer v1.0.1 h1:XRztA5MXiR1TIRHxH2uNxXxaIkKQDeX7m2XsSOlQEnM=
-github.com/technoweenie/multipartstreamer v1.0.1/go.mod h1:jNVxdtShOxzAsukZwTSw6MDx5eUJoiEBsSvzDU9uzog=
 github.com/urfave/cli v1.22.15 h1:nuqt+pdC/KqswQKhETJjo7pvn/k4xMUxgW6liI7XpnM=
 github.com/urfave/cli v1.22.15/go.mod h1:wSan1hmo5zeyLGBjRJbzRTNk8gwoYa2B9n4q9dmRIc0=
 golang.org/x/crypto v0.27.0 h1:GXm2NjJrPaiv/h1tb2UH8QfgC/hOf/+z0p6PT8o1w7A=

--- a/main.go
+++ b/main.go
@@ -263,6 +263,11 @@ func main() {
 			Usage:  "Socks5 proxy URL",
 			EnvVar: "PLUGIN_SOCKS5,SOCKS5,INPUT_SOCKS5",
 		},
+		cli.BoolFlag{
+			Name:   "skipgetme",
+			Usage:  "Boolean value, indicates to skip getMe request",
+			EnvVar: "PLUGIN_SKIP_GETME,SKIP_GETME",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -324,6 +329,7 @@ func run(c *cli.Context) error {
 			Venue:            c.StringSlice("venue"),
 			Format:           c.String("format"),
 			GitHub:           c.Bool("github"),
+			SkipGetMe:        c.Bool("skipgetme"),
 			Socks5:           c.String("socks5"),
 
 			DisableWebPagePreview: c.Bool("disable.webpage.preview"),

--- a/plugin.go
+++ b/plugin.go
@@ -89,6 +89,7 @@ type (
 		Venue            []string
 		Format           string
 		GitHub           bool
+		SkipGetMe        bool
 		Socks5           string
 
 		DisableWebPagePreview bool
@@ -578,6 +579,9 @@ func (p Plugin) newBot() (*tgbotapi.Bot, error) {
 	}
 	if p.Config.Debug {
 		options = append(options, tgbotapi.WithDebug())
+	}
+	if p.Config.SkipGetMe {
+		options = append(options, tgbotapi.WithSkipGetMe())
 	}
 	return tgbotapi.New(p.Config.Token, options...)
 }

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -254,19 +254,19 @@ func TestEscapeMarkdownOne(t *testing.T) {
 }
 
 func TestParseTo(t *testing.T) {
-	input := []string{"0", "1:1@gmail.com", "2:2@gmail.com", "3:3@gmail.com", "4", "5"}
+	input := []string{"0", "1:1@gmail.com", "2:2@gmail.com", "3:3@gmail.com", "4", "5#7"}
 
 	ids := parseTo(input, "1@gmail.com", false)
-	assert.Equal(t, []int64{0, 4, 5, 1}, ids)
+	assert.Equal(t, []Chat{Chat{0, 0}, Chat{4, 0}, Chat{5, 7}, Chat{1, 0}}, ids)
 
 	ids = parseTo(input, "1@gmail.com", true)
-	assert.Equal(t, []int64{1}, ids)
+	assert.Equal(t, []Chat{Chat{1, 0}}, ids)
 
 	ids = parseTo(input, "a@gmail.com", false)
-	assert.Equal(t, []int64{0, 4, 5}, ids)
+	assert.Equal(t, []Chat{Chat{0, 0}, Chat{4, 0}, Chat{5, 7}}, ids)
 
 	ids = parseTo(input, "a@gmail.com", true)
-	assert.Equal(t, []int64{0, 4, 5}, ids)
+	assert.Equal(t, []Chat{Chat{0, 0}, Chat{4, 0}, Chat{5, 7}}, ids)
 
 	// test empty ids
 	ids = parseTo([]string{"", " ", "   "}, "a@gmail.com", true)


### PR DESCRIPTION
1. Migration to github.com/go-telegram/bot. Previously not support message_thread_id tag
2. Support pass message_thread_id


```
 - name: notify
    image: appleboy/drone-telegram
    when:
        status: [ success, failure ]
    settings:
        token:
            from_secret: tg_bot_secret
        to: '12345#678'
```
ChatID: 12345
MessageThreadID: 678